### PR TITLE
Dbatiste/remove root pseudo selector

### DIFF
--- a/d2l-colors.html
+++ b/d2l-colors.html
@@ -1,56 +1,51 @@
 <link rel="import" href="../polymer/polymer.html">
-<dom-module id="d2l-colors">
-	<template>
-		<style>
-			:root {
-				/* primary palette */
-				--d2l-color-carnelian: #e57231;
-				--d2l-color-celestine: #006fbf;
+<style is="custom-style">
+	html {
+		/* primary palette */
+		--d2l-color-carnelian: #e57231;
+		--d2l-color-celestine: #006fbf;
 
-				/* secondary palette */
-				--d2l-color-azurite: #00a4c0;
-				--d2l-color-celestuba: #1c5295;
-				--d2l-color-cinnabar: #cd2026;
-				--d2l-color-citrine: #ffba59;
-				--d2l-color-olivine: #46a661;
-				--d2l-color-zircon: #00bddd;
+		/* secondary palette */
+		--d2l-color-azurite: #00a4c0;
+		--d2l-color-celestuba: #1c5295;
+		--d2l-color-cinnabar: #cd2026;
+		--d2l-color-citrine: #ffba59;
+		--d2l-color-olivine: #46a661;
+		--d2l-color-zircon: #00bddd;
 
-				/* tertiary palette (for gradients) */
-				--d2l-color-lurite: #f5ec5a;
-				--d2l-color-panthera: #ff389b;
-				--d2l-color-gravah: #32075b;
-				--d2l-color-saphirella: #00a8dd;
-				--d2l-color-violettine: #4c3f99;
-				--d2l-color-chartronic: #d2e830;
-				--d2l-color-deephonica: #00afaa;
-				--d2l-color-koolaudica: #69be28;
+		/* tertiary palette (for gradients) */
+		--d2l-color-lurite: #f5ec5a;
+		--d2l-color-panthera: #ff389b;
+		--d2l-color-gravah: #32075b;
+		--d2l-color-saphirella: #00a8dd;
+		--d2l-color-violettine: #4c3f99;
+		--d2l-color-chartronic: #d2e830;
+		--d2l-color-deephonica: #00afaa;
+		--d2l-color-koolaudica: #69be28;
 
-				/* the lighter side */
-				--d2l-color-celestine-light-1: #f2f8fc;
-				--d2l-color-celestine-light-2: #99c5e5;
-				--d2l-color-olivine-light-1: #ecf6ee;
-				--d2l-color-olivine-light-2: #65b57b;
-				--d2l-color-zircon-light-1: #dbf5fa;
-				--d2l-color-zircon-light-2: #bdedf5;
+		/* the lighter side */
+		--d2l-color-celestine-light-1: #f2f8fc;
+		--d2l-color-celestine-light-2: #99c5e5;
+		--d2l-color-olivine-light-1: #ecf6ee;
+		--d2l-color-olivine-light-2: #65b57b;
+		--d2l-color-zircon-light-1: #dbf5fa;
+		--d2l-color-zircon-light-2: #bdedf5;
 
-				/* shades of grey */
-				--d2l-color-ferrite: #565a5c;
-				--d2l-color-galena: #7c8695;
-				--d2l-color-gypsum: #e6eaf0;
-				--d2l-color-pressicus: #b9c2d0;
-				--d2l-color-regolith: #f9fafb;
-				--d2l-color-titanius: #d3d9e3;
-				--d2l-color-tungsten: #72777a;
-				--d2l-color-white: #fff;
-				--d2l-color-woolonardo: #f2f3f5;
+		/* shades of grey */
+		--d2l-color-ferrite: #565a5c;
+		--d2l-color-galena: #7c8695;
+		--d2l-color-gypsum: #e6eaf0;
+		--d2l-color-pressicus: #b9c2d0;
+		--d2l-color-regolith: #f9fafb;
+		--d2l-color-titanius: #d3d9e3;
+		--d2l-color-tungsten: #72777a;
+		--d2l-color-white: #fff;
+		--d2l-color-woolonardo: #f2f3f5;
 
-				/* gradients */
-				--d2l-color-buttonic: linear-gradient(to bottom, $d2l-color-regolith 0%, $d2l-color-gypsum 100%);
-				--d2l-color-meglor: linear-gradient(to bottom, $d2l-color-pressicus 0%, $d2l-color-tungsten 100%);
-				--d2l-color-trancition: linear-gradient(to bottom, $d2l-color-white 0%, $d2l-color-regolith 100%);
-				--d2l-color-trixon: linear-gradient(to bottom, $d2l-color-regolith 0%, $d2l-color-woolonardo 100%);
-
-			}
-		</style>
-	</template>
-</dom-module>
+		/* gradients */
+		--d2l-color-buttonic: linear-gradient(to bottom, $d2l-color-regolith 0%, $d2l-color-gypsum 100%);
+		--d2l-color-meglor: linear-gradient(to bottom, $d2l-color-pressicus 0%, $d2l-color-tungsten 100%);
+		--d2l-color-trancition: linear-gradient(to bottom, $d2l-color-white 0%, $d2l-color-regolith 100%);
+		--d2l-color-trixon: linear-gradient(to bottom, $d2l-color-regolith 0%, $d2l-color-woolonardo 100%);
+	}
+</style>

--- a/d2l-colors.html
+++ b/d2l-colors.html
@@ -43,9 +43,9 @@
 		--d2l-color-woolonardo: #f2f3f5;
 
 		/* gradients */
-		--d2l-color-buttonic: linear-gradient(to bottom, $d2l-color-regolith 0%, $d2l-color-gypsum 100%);
-		--d2l-color-meglor: linear-gradient(to bottom, $d2l-color-pressicus 0%, $d2l-color-tungsten 100%);
-		--d2l-color-trancition: linear-gradient(to bottom, $d2l-color-white 0%, $d2l-color-regolith 100%);
-		--d2l-color-trixon: linear-gradient(to bottom, $d2l-color-regolith 0%, $d2l-color-woolonardo 100%);
+		--d2l-color-buttonic: linear-gradient(to bottom, var(--d2l-color-regolith) 0%, var(--d2l-color-gypsum) 100%);
+		--d2l-color-meglor: linear-gradient(to bottom, var(--d2l-color-pressicus) 0%, var(--d2l-color-tungsten) 100%);
+		--d2l-color-trancition: linear-gradient(to bottom, var(--d2l-color-white) 0%, var(--d2l-color-regolith) 100%);
+		--d2l-color-trixon: linear-gradient(to bottom, var(--d2l-color-regolith) 0%, var(--d2l-color-woolonardo) 100%);
 	}
 </style>


### PR DESCRIPTION
@awikkerink , @dlockhart :

This changes the selector for defining the color palette from `:root` to `html`, and moves them into a custom-style element.  With this change, the colors still appear to be accessible from web components (usable in their shadow-DOM), and in other custom-style elements (ex. BSI styles that produce CSS for LMS).

With this change, consumers will no longer need to `include="d2l-colors"`, and until those components are updated, warnings will be seem in browser console.

Within `d2l-icons`, performance tests on `d2l-icon` reveal a 35% init improvement (on 250 icons in Chrome -> 296.9ms (`:root`) down to 192.4ms (`html`))  (aside, icons still need a revamp as this is still very high, and is on my list).  I did a bunch of perf tests using LMS and found negligible perf improvement in Chrome, and ~8% improvement in IE.  With the limited data from manual testing, I am not convinced the LMS perf changes are consistent/significant, but this is a change we will need to make anyway (since `:root` is going way).
