### PR TITLE
Polymer2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 bower_components
+bower_components-1.x
 node_modules/
 test/test.css
+bower-1.x.json

--- a/bower.json
+++ b/bower.json
@@ -27,7 +27,7 @@
     "polymer": "Polymer/polymer#^1.9.1 || ^2.0.0"
   },
   "devDependencies": {
-    "d2l-demo-template": "mdgbayly/d2l-demo-template-ui#polymer2"
+    "d2l-demo-template": "^0.0.11"
   },
   "variants": {
     "1.x": {
@@ -35,7 +35,7 @@
         "polymer": "Polymer/polymer#^1.7.0"
       },
       "devDependencies": {
-        "d2l-demo-template": "mdgbayly/d2l-demo-template-ui#polymer2"
+        "d2l-demo-template": "^0.0.11"
       }
     }
   }

--- a/bower.json
+++ b/bower.json
@@ -27,7 +27,7 @@
     "polymer": "Polymer/polymer#^1.9.1 || ^2.0.0"
   },
   "devDependencies": {
-    "d2l-demo-template": "mdgbayly/d2l-demo-template#polymer2"
+    "d2l-demo-template": "mdgbayly/d2l-demo-template-ui#polymer2"
   },
   "variants": {
     "1.x": {
@@ -35,7 +35,7 @@
         "polymer": "Polymer/polymer#^1.7.0"
       },
       "devDependencies": {
-        "d2l-demo-template": "mdgbayly/d2l-demo-template#polymer2"
+        "d2l-demo-template": "mdgbayly/d2l-demo-template-ui#polymer2"
       }
     }
   }

--- a/bower.json
+++ b/bower.json
@@ -36,6 +36,9 @@
       },
       "devDependencies": {
         "d2l-demo-template": "^1.0.0"
+      },
+      "resolutions": {
+        "webcomponentsjs": "^0.7"
       }
     }
   },

--- a/bower.json
+++ b/bower.json
@@ -27,16 +27,19 @@
     "polymer": "Polymer/polymer#^1.9.1 || ^2.0.0"
   },
   "devDependencies": {
-    "d2l-demo-template": "^0.0.11"
+    "d2l-demo-template": "^1.0.0"
   },
   "variants": {
     "1.x": {
       "dependencies": {
-        "polymer": "Polymer/polymer#^1.7.0"
+        "polymer": "Polymer/polymer#^1.9.1"
       },
       "devDependencies": {
-        "d2l-demo-template": "^0.0.11"
+        "d2l-demo-template": "^1.0.0"
       }
     }
+  },
+  "resolutions": {
+    "webcomponentsjs": "^v1.0.0"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -24,9 +24,19 @@
     "test"
   ],
   "dependencies": {
-    "polymer": "^1.7.0"
+    "polymer": "Polymer/polymer#^1.9.1 || ^2.0.0"
   },
   "devDependencies": {
-    "d2l-demo-template": "^0.0.11"
+    "d2l-demo-template": "mdgbayly/d2l-demo-template#polymer2"
+  },
+  "variants": {
+    "1.x": {
+      "dependencies": {
+        "polymer": "Polymer/polymer#^1.7.0"
+      },
+      "devDependencies": {
+        "d2l-demo-template": "mdgbayly/d2l-demo-template#polymer2"
+      }
+    }
   }
 }

--- a/d2l-colors.html
+++ b/d2l-colors.html
@@ -1,56 +1,58 @@
 <link rel="import" href="../polymer/polymer.html">
-<style is="custom-style">
-	html {
-		/* primary palette */
-		--d2l-color-carnelian: #e57231;
-		--d2l-color-celestine: #006fbf;
+<custom-style>
+	<style is="custom-style">
+		html {
+			/* primary palette */
+			--d2l-color-carnelian: #e57231;
+			--d2l-color-celestine: #006fbf;
 
-		/* secondary palette */
-		--d2l-color-azurite: #00a4c0;
-		--d2l-color-celestuba: #1c5295;
-		--d2l-color-cinnabar: #cd2026;
-		--d2l-color-citrine: #ffba59;
-		--d2l-color-olivine: #46a661;
-		--d2l-color-zircon: #00bddd;
-		--d2l-color-topaz: #f5ec5a;
-		--d2l-color-fluorite: #b24ac7;
+			/* secondary palette */
+			--d2l-color-azurite: #00a4c0;
+			--d2l-color-celestuba: #1c5295;
+			--d2l-color-cinnabar: #cd2026;
+			--d2l-color-citrine: #ffba59;
+			--d2l-color-olivine: #46a661;
+			--d2l-color-zircon: #00bddd;
+			--d2l-color-topaz: #f5ec5a;
+			--d2l-color-fluorite: #b24ac7;
 
-		/* tertiary palette (for gradients) */
-		--d2l-color-lurite: #f5ec5a;
-		--d2l-color-panthera: #ff389b;
-		--d2l-color-gravah: #32075b;
-		--d2l-color-saphirella: #00a8dd;
-		--d2l-color-violettine: #4c3f99;
-		--d2l-color-chartronic: #d2e830;
-		--d2l-color-deephonica: #00afaa;
-		--d2l-color-koolaudica: #69be28;
+			/* tertiary palette (for gradients) */
+			--d2l-color-lurite: #f5ec5a;
+			--d2l-color-panthera: #ff389b;
+			--d2l-color-gravah: #32075b;
+			--d2l-color-saphirella: #00a8dd;
+			--d2l-color-violettine: #4c3f99;
+			--d2l-color-chartronic: #d2e830;
+			--d2l-color-deephonica: #00afaa;
+			--d2l-color-koolaudica: #69be28;
 
-		/* the lighter side */
-		--d2l-color-celestine-light-1: #f2f8fc;
-		--d2l-color-celestine-light-2: #99c5e5;
-		--d2l-color-olivine-light-1: #ecf6ee;
-		--d2l-color-olivine-light-2: #65b57b;
-		--d2l-color-zircon-light-1: #dbf5fa;
-		--d2l-color-zircon-light-2: #bdedf5;
+			/* the lighter side */
+			--d2l-color-celestine-light-1: #f2f8fc;
+			--d2l-color-celestine-light-2: #99c5e5;
+			--d2l-color-olivine-light-1: #ecf6ee;
+			--d2l-color-olivine-light-2: #65b57b;
+			--d2l-color-zircon-light-1: #dbf5fa;
+			--d2l-color-zircon-light-2: #bdedf5;
 
-		/* new lighter/plus versions */
-		--d2l-color-celestine-plus-1: #29a6ff;
+			/* new lighter/plus versions */
+			--d2l-color-celestine-plus-1: #29a6ff;
 
-		/* shades of grey */
-		--d2l-color-ferrite: #565a5c;
-		--d2l-color-galena: #7c8695;
-		--d2l-color-gypsum: #e6eaf0;
-		--d2l-color-pressicus: #b9c2d0;
-		--d2l-color-regolith: #f9fafb;
-		--d2l-color-titanius: #d3d9e3;
-		--d2l-color-tungsten: #72777a;
-		--d2l-color-white: #fff;
-		--d2l-color-woolonardo: #f2f3f5;
+			/* shades of grey */
+			--d2l-color-ferrite: #565a5c;
+			--d2l-color-galena: #7c8695;
+			--d2l-color-gypsum: #e6eaf0;
+			--d2l-color-pressicus: #b9c2d0;
+			--d2l-color-regolith: #f9fafb;
+			--d2l-color-titanius: #d3d9e3;
+			--d2l-color-tungsten: #72777a;
+			--d2l-color-white: #fff;
+			--d2l-color-woolonardo: #f2f3f5;
 
-		/* gradients */
-		--d2l-color-buttonic: linear-gradient(to bottom, var(--d2l-color-regolith) 0%, var(--d2l-color-gypsum) 100%);
-		--d2l-color-meglor: linear-gradient(to bottom, var(--d2l-color-pressicus) 0%, var(--d2l-color-tungsten) 100%);
-		--d2l-color-trancition: linear-gradient(to bottom, var(--d2l-color-white) 0%, var(--d2l-color-regolith) 100%);
-		--d2l-color-trixon: linear-gradient(to bottom, var(--d2l-color-regolith) 0%, var(--d2l-color-woolonardo) 100%);
-	}
-</style>
+			/* gradients */
+			--d2l-color-buttonic: linear-gradient(to bottom, var(--d2l-color-regolith) 0%, var(--d2l-color-gypsum) 100%);
+			--d2l-color-meglor: linear-gradient(to bottom, var(--d2l-color-pressicus) 0%, var(--d2l-color-tungsten) 100%);
+			--d2l-color-trancition: linear-gradient(to bottom, var(--d2l-color-white) 0%, var(--d2l-color-regolith) 100%);
+			--d2l-color-trixon: linear-gradient(to bottom, var(--d2l-color-regolith) 0%, var(--d2l-color-woolonardo) 100%);
+		}
+	</style>
+</custom-style>

--- a/demo/index.html
+++ b/demo/index.html
@@ -2,13 +2,13 @@
 <html>
 	<head>
 		<title>Colors Sample</title>
-		<script src="https://s.brightspace.com/lib/webcomponentsjs/0.7.21/webcomponents-lite.min.js"></script>
+		<script src="../../webcomponentsjs/webcomponents-lite.js"></script>
 		<link rel="import" href="../../d2l-demo-template/d2l-demo-template.html">
 		<link rel="import" href="color-swatch.html">
 	</head>
 	<body unresolved>
 		<d2l-demo-template title="d2l-colors">
-			<div class="d2l-demo-fixture">
+			<div slot="d2l-demo-fixture">
 
 				<h1>Colors</h1>
 

--- a/demo/index.html
+++ b/demo/index.html
@@ -8,7 +8,7 @@
 	</head>
 	<body unresolved>
 		<d2l-demo-template title="d2l-colors">
-			<div class="d2l-demo-fixture" slot="d2l-demo-fixture">
+			<div slot="d2l-demo-fixture">
 
 				<h1>Colors</h1>
 

--- a/demo/index.html
+++ b/demo/index.html
@@ -8,7 +8,7 @@
 	</head>
 	<body unresolved>
 		<d2l-demo-template title="d2l-colors">
-			<div slot="d2l-demo-fixture">
+			<div class="d2l-demo-fixture" slot="d2l-demo-fixture">
 
 				<h1>Colors</h1>
 

--- a/package.json
+++ b/package.json
@@ -12,11 +12,11 @@
     "web component"
   ],
   "scripts": {
-    "postinstall": "bower install",
+    "postinstall": "polymer install --variants",
     "build:sass": "node-sass ./test/test.scss ./test/test.css",
     "test:lint": "npm run test:lint:wc && npm run test:lint:html",
     "test:lint:html": "eslint *.html",
-    "test:lint:wc": "polymer lint -i d2l-colors.html",
+    "test:lint:wc": "polymer lint",
     "test": "npm run test:lint && npm run build:sass"
   },
   "repository": {
@@ -31,6 +31,6 @@
     "eslint-config-brightspace": "^0.2.4",
     "eslint-plugin-html": "^1.5.3",
     "node-sass": "^3.7.0",
-    "polymer-cli": "^0.16.0"
+    "polymer-cli": "^1.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "eslint": "^3.7.1",
     "eslint-config-brightspace": "^0.2.4",
     "eslint-plugin-html": "^1.5.3",
-    "node-sass": "^3.7.0",
+    "node-sass": "^4.5.0",
     "polymer-cli": "^1.1.0"
   }
 }

--- a/polymer.json
+++ b/polymer.json
@@ -1,0 +1,9 @@
+{
+    "sources": [
+        "*.html"
+    ],
+    "lint": {
+      "rules": ["polymer-2-hybrid"],
+      "ignoreWarnings": []
+    }
+}


### PR DESCRIPTION
Support for Polymer 2.
Main change is to wrap the `style is="custom-style"` tag in a `<custom-style>` tag.
Append ?w=1 to github URL to remove whitespace changes caused by the additional indentation.

This will probably need to be a major version bump, because it has a dependency on d2l-demo-template-ui which should also probably be a major version bump because it includes the change to switch from `content` to `slot`.

