### PR TITLE
GAUD-8826: removing unnecessary dependencies

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,0 @@
-test/acceptance/*
-reports

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,3 +1,0 @@
-{
-  "extends": "brightspace/polymer-3-config"
-}

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 node_modules/
-test/test.css
 package-lock.json

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-*       @dlockhart @dbatiste
+*       @BrightspaceUI/gaudi-dev

--- a/demo/index.html
+++ b/demo/index.html
@@ -2,7 +2,6 @@
 <html>
 	<head>
 		<title>Colors Sample</title>
-		<script src="../../@webcomponents/webcomponentsjs/webcomponents-bundle.js"></script>
 		<script type="module" src="./color-swatch.js"></script>
 	</head>
 	<body unresolved>

--- a/package.json
+++ b/package.json
@@ -14,34 +14,17 @@
   },
   "name": "d2l-colors",
   "scripts": {
-    "build:sass": "node-sass ./test/test.scss ./test/test.css",
-    "test:lint": "npm run test:lint:wc && npm run test:lint:js",
-    "test:lint:js": "eslint . --ext .js,.html test/**/*.js test/**/*.html demo/**/*.js demo/**/*.html",
-    "test:lint:wc": "polymer lint",
-    "test": "npm run test:lint && npm run build:sass"
+    "start": "web-dev-server --node-resolve --watch --open --root-dir demo"
   },
   "author": "D2L Corporation",
   "license": "Apache-2.0",
   "devDependencies": {
-    "@babel/polyfill": "^7.0.0",
-    "@webcomponents/webcomponentsjs": "^2.2.1",
-    "babel-eslint": "^10.0.1",
-    "eslint": "^4.15.0",
-    "eslint-config-brightspace": "^0.4.0",
-    "eslint-plugin-html": "^4.0.1",
-    "node-sass": "^4.5.0",
-    "polymer-cli": "^1.9.1"
+    "@web/dev-server": "^0.4"
   },
   "version": "4.4.3",
-  "resolutions": {
-    "inherits": "2.0.3",
-    "samsam": "1.1.3",
-    "supports-color": "3.1.2",
-    "type-detect": "1.0.0"
-  },
   "main": "d2l-colors.js",
   "dependencies": {
     "@brightspace-ui/core": "^1",
-    "@polymer/polymer": "^3.0.0"
+    "@polymer/polymer": "^3"
   }
 }


### PR DESCRIPTION
`node-sass` doesn't even install anymore and is causing security warnings. This entire repo is just a wrapper around `@brightspace-ui/core`'s color stuff, so there's not really any point in it having tests or linting.