### PR TITLE
fix: Copy over core's sass variables

### DIFF
--- a/d2l-colors.scss
+++ b/d2l-colors.scss
@@ -1,4 +1,89 @@
-@import 'node_modules/@brightspace-ui/core/components/colors/colors.scss';
+// basic grays (lightest to darkest)
+$d2l-color-regolith: #f9fbff !default;
+$d2l-color-sylvite: #f1f5fb !default;
+$d2l-color-gypsum: #e3e9f1 !default;
+$d2l-color-mica: #cdd5dc !default;
+$d2l-color-corundum: #b1b9be !default;
+$d2l-color-chromite: #90989d !default;
+$d2l-color-galena: #6e7477 !default;
+$d2l-color-tungsten: #494c4e !default;
+$d2l-color-ferrite: #202122 !default;
+
+// zircon
+$d2l-color-zircon-plus-2: #e0feff !default;
+$d2l-color-zircon-plus-1: #00d2ed !default;
+$d2l-color-zircon: #008eab !default;
+$d2l-color-zircon-minus-1: #035670 !default;
+
+// celestine
+$d2l-color-celestine-plus-2: #e8f8ff !default;
+$d2l-color-celestine-plus-1: #29a6ff !default;
+$d2l-color-celestine: #006fbf !default;
+$d2l-color-celestine-minus-1: #004489 !default;
+
+// amethyst
+$d2l-color-amethyst-plus-2: #f2f0ff !default;
+$d2l-color-amethyst-plus-1: #8982ff !default;
+$d2l-color-amethyst: #6038ff !default;
+$d2l-color-amethyst-minus-1: #4500db !default;
+
+// fluorite
+$d2l-color-fluorite-plus-2: #f9ebff !default;
+$d2l-color-fluorite-plus-1: #ce68fa !default;
+$d2l-color-fluorite: #9d1fd4 !default;
+$d2l-color-fluorite-minus-1: #6900a0 !default;
+
+// tourmaline
+$d2l-color-tourmaline-plus-2: #ffebf6 !default;
+$d2l-color-tourmaline-plus-1: #fd4e9d !default;
+$d2l-color-tourmaline: #d40067 !default;
+$d2l-color-tourmaline-minus-1: #990056 !default;
+
+// cinnabar
+$d2l-color-cinnabar-plus-2: #ffede8 !default;
+$d2l-color-cinnabar-plus-1: #ff575a !default;
+$d2l-color-cinnabar: #cd2026 !default;
+$d2l-color-cinnabar-minus-1: #990006 !default;
+
+// carnelian
+$d2l-color-carnelian-plus-1: #fff3e0 !default;
+$d2l-color-carnelian: #e87511 !default;
+$d2l-color-carnelian-minus-1: #ba4700 !default;
+$d2l-color-carnelian-minus-2: #7d2600 !default;
+
+// citrine
+$d2l-color-citrine-plus-1: #fff9d6 !default;
+$d2l-color-citrine: #ffba59 !default;
+$d2l-color-citrine-minus-1: #c47400 !default;
+$d2l-color-citrine-minus-2: #7a4300 !default;
+
+// peridot
+$d2l-color-peridot-plus-1: #efffd9 !default;
+$d2l-color-peridot: #8ad934 !default;
+$d2l-color-peridot-minus-1: #4a8f00 !default;
+$d2l-color-peridot-minus-2: #2f5e00 !default;
+
+// olivine
+$d2l-color-olivine-plus-1: #e7ffe3 !default;
+$d2l-color-olivine: #46a661 !default;
+$d2l-color-olivine-minus-1: #027a21 !default;
+$d2l-color-olivine-minus-2: #005614 !default;
+
+// malachite
+$d2l-color-malachite-plus-1: #e3fff5 !default;
+$d2l-color-malachite: #2de2c0 !default;
+$d2l-color-malachite-minus-1: #00a490 !default;
+$d2l-color-malachite-minus-2: #00635e !default;
+
+// primary accent
+$d2l-color-primary-accent-action: $d2l-color-celestine !default;
+$d2l-color-primary-accent-indicator: $d2l-color-carnelian !default;
+
+// feedback
+$d2l-color-feedback-error: $d2l-color-cinnabar !default;
+$d2l-color-feedback-warning: $d2l-color-carnelian !default;
+$d2l-color-feedback-success: $d2l-color-olivine !default;
+$d2l-color-feedback-action: $d2l-color-celestine !default;
 
 // deprecated
 $d2l-color-woolonardo: $d2l-color-sylvite !default;


### PR DESCRIPTION
[GAUD-8846](https://desire2learn.atlassian.net/browse/GAUD-8846)

Although we could just entirely remove this file, I checked out latest of old major versions of `BrightspaceUI/Table` and `BrightpsaceUI/Input` and they were not using them, but older minor versions were. So it felt safer to just copy the variables over.

[GAUD-8846]: https://desire2learn.atlassian.net/browse/GAUD-8846?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ